### PR TITLE
feat: add Brevo API mail transport for firewall bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@
   - Added Brevo API configuration to `config/services.php` for optional HTTP API fallback
   - Added comprehensive email configuration feature tests covering SMTP settings, notifications, and environment checks
   - Environment variable support for MAIL_EHLO_DOMAIN and MAIL_VERIFY_PEER
+  - Implemented custom Brevo API mail transport (`BrevoApiTransport`) to bypass firewall restrictions
+  - Installed `getbrevo/brevo-php` SDK for HTTP API integration
+  - Registered custom mail transport in `AppServiceProvider` for seamless Laravel Mail integration
 
 ### Changed
 
 - Enhanced SMTP mailer configuration with explicit `encryption` parameter and SSL verification
-- Mail configuration now properly supports both development (Mailpit) and production (Brevo SMTP) environments
+- Mail configuration now properly supports both development (Mailpit) and production (Brevo SMTP/API) environments
+- Updated documentation to recommend Brevo API for production (bypasses SMTP port blocking)
 
 ### Fixed
 

--- a/app/Mail/Transport/BrevoApiTransport.php
+++ b/app/Mail/Transport/BrevoApiTransport.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Transport;
+
+use Brevo\Client\Api\TransactionalEmailsApi;
+use Brevo\Client\Configuration;
+use Brevo\Client\Model\SendSmtpEmail;
+use GuzzleHttp\Client;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\MessageConverter;
+
+final class BrevoApiTransport extends AbstractTransport
+{
+    public function __construct(
+        private readonly string $apiKey
+    ) {
+        parent::__construct();
+    }
+
+    protected function doSend(SentMessage $message): void
+    {
+        $email = MessageConverter::toEmail($message->getOriginalMessage());
+
+        $config = Configuration::getDefaultConfiguration()->setApiKey('api-key', $this->apiKey);
+        $apiInstance = new TransactionalEmailsApi(new Client, $config);
+
+        $sendSmtpEmail = new SendSmtpEmail;
+
+        // Set sender
+        $from = $email->getFrom();
+        if (count($from) > 0) {
+            $fromAddress = $from[0];
+            $sendSmtpEmail->setSender([
+                'email' => $fromAddress->getAddress(),
+                'name' => $fromAddress->getName() ?? config('mail.from.name'),
+            ]);
+        }
+
+        // Set recipients
+        $to = array_map(function (Address $address) {
+            return [
+                'email' => $address->getAddress(),
+                'name' => $address->getName(),
+            ];
+        }, $email->getTo());
+        $sendSmtpEmail->setTo($to);
+
+        // Set CC
+        if (count($email->getCc()) > 0) {
+            $cc = array_map(function (Address $address) {
+                return [
+                    'email' => $address->getAddress(),
+                    'name' => $address->getName(),
+                ];
+            }, $email->getCc());
+            $sendSmtpEmail->setCc($cc);
+        }
+
+        // Set BCC
+        if (count($email->getBcc()) > 0) {
+            $bcc = array_map(function (Address $address) {
+                return [
+                    'email' => $address->getAddress(),
+                    'name' => $address->getName(),
+                ];
+            }, $email->getBcc());
+            $sendSmtpEmail->setBcc($bcc);
+        }
+
+        // Set subject
+        $sendSmtpEmail->setSubject($email->getSubject());
+
+        // Set reply-to
+        $replyTo = $email->getReplyTo();
+        if (count($replyTo) > 0) {
+            $replyToAddress = $replyTo[0];
+            $sendSmtpEmail->setReplyTo([
+                'email' => $replyToAddress->getAddress(),
+                'name' => $replyToAddress->getName(),
+            ]);
+        }
+
+        // Set HTML and text content
+        if ($email->getHtmlBody()) {
+            $sendSmtpEmail->setHtmlContent($email->getHtmlBody());
+        }
+
+        if ($email->getTextBody()) {
+            $sendSmtpEmail->setTextContent($email->getTextBody());
+        }
+
+        // Send email via Brevo API
+        $apiInstance->sendTransacEmail($sendSmtpEmail);
+    }
+
+    public function __toString(): string
+    {
+        return 'brevo+api';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace App\Providers;
 
+use App\Mail\Transport\BrevoApiTransport;
 use App\Models\User;
 use App\Policies\UserPolicy;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
@@ -28,6 +30,19 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(User::class, UserPolicy::class);
 
         $this->configureRateLimiting();
+        $this->configureMailTransports();
+    }
+
+    /**
+     * Configure custom mail transports.
+     */
+    protected function configureMailTransports(): void
+    {
+        Mail::extend('brevo', function (array $config) {
+            return new BrevoApiTransport(
+                apiKey: $config['api_key'] ?? config('services.brevo.api_key')
+            );
+        });
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "getbrevo/brevo-php": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "league/commonmark": "^2.4",

--- a/config/mail.php
+++ b/config/mail.php
@@ -66,6 +66,11 @@ return [
             'transport' => 'resend',
         ],
 
+        'brevo' => [
+            'transport' => 'brevo',
+            'api_key' => env('BREVO_API_KEY'),
+        ],
+
         'sendmail' => [
             'transport' => 'sendmail',
             'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),


### PR DESCRIPTION
- Implement custom BrevoApiTransport class for sending emails via Brevo HTTP API
- Install getbrevo/brevo-php SDK (v2.0.13)
- Register custom mail transport in AppServiceProvider
- Add brevo mailer configuration to config/mail.php
- Update EMAIL_SETUP.md with comprehensive API setup instructions
- Document advantages of API vs SMTP (no firewall issues, faster, more reliable)
- All 44 tests passing

The API transport bypasses SMTP port blocking common on hosting providers and is now the recommended method for production deployments.